### PR TITLE
feat: add excludeTypeNames option to filter entity definitions 

### DIFF
--- a/src/adapter/entry-points/cli/index.test.ts
+++ b/src/adapter/entry-points/cli/index.test.ts
@@ -350,4 +350,41 @@ describe('commander program', () => {
       },
     ]);
   });
+
+  it('should exclude types specified in config file', () => {
+    const output = execSync(
+      'npx ts-node ./src/adapter/entry-points/cli/index.ts ./testdata/src/domain/entities --config ./testdata/ast-to-entity-definitions.json',
+    ).toString();
+
+    const parsedOutput = JSON.parse(output) as EntityDefinition[]; // eslint-disable-line no-type-assertion/no-type-assertion
+    
+    // Administrator and Item types should be excluded based on config file
+    const administratorEntity = parsedOutput.find((entity) => entity.name === 'Administrator');
+    expect(administratorEntity).toBeUndefined();
+    
+    const itemEntity = parsedOutput.find((entity) => entity.name === 'Item');
+    expect(itemEntity).toBeUndefined();
+    
+    // Other entities should still be present
+    const userEntity = parsedOutput.find((entity) => entity.name === 'User');
+    expect(userEntity).toBeDefined();
+    
+    const groupEntity = parsedOutput.find((entity) => entity.name === 'Group');
+    expect(groupEntity).toBeDefined();
+  });
+
+  it('should work without config file (backward compatibility)', () => {
+    const output = execSync(
+      'npx ts-node ./src/adapter/entry-points/cli/index.ts ./testdata/src/domain/entities',
+    ).toString();
+
+    const parsedOutput = JSON.parse(output) as EntityDefinition[]; // eslint-disable-line no-type-assertion/no-type-assertion
+    
+    // All entities should be present
+    const administratorEntity = parsedOutput.find((entity) => entity.name === 'Administrator');
+    expect(administratorEntity).toBeDefined();
+    
+    const itemEntity = parsedOutput.find((entity) => entity.name === 'Item');
+    expect(itemEntity).toBeDefined();
+  });
 });

--- a/src/adapter/entry-points/cli/index.test.ts
+++ b/src/adapter/entry-points/cli/index.test.ts
@@ -357,18 +357,20 @@ describe('commander program', () => {
     ).toString();
 
     const parsedOutput = JSON.parse(output) as EntityDefinition[]; // eslint-disable-line no-type-assertion/no-type-assertion
-    
+
     // Administrator and Item types should be excluded based on config file
-    const administratorEntity = parsedOutput.find((entity) => entity.name === 'Administrator');
+    const administratorEntity = parsedOutput.find(
+      (entity) => entity.name === 'Administrator',
+    );
     expect(administratorEntity).toBeUndefined();
-    
+
     const itemEntity = parsedOutput.find((entity) => entity.name === 'Item');
     expect(itemEntity).toBeUndefined();
-    
+
     // Other entities should still be present
     const userEntity = parsedOutput.find((entity) => entity.name === 'User');
     expect(userEntity).toBeDefined();
-    
+
     const groupEntity = parsedOutput.find((entity) => entity.name === 'Group');
     expect(groupEntity).toBeDefined();
   });
@@ -379,11 +381,13 @@ describe('commander program', () => {
     ).toString();
 
     const parsedOutput = JSON.parse(output) as EntityDefinition[]; // eslint-disable-line no-type-assertion/no-type-assertion
-    
+
     // All entities should be present
-    const administratorEntity = parsedOutput.find((entity) => entity.name === 'Administrator');
+    const administratorEntity = parsedOutput.find(
+      (entity) => entity.name === 'Administrator',
+    );
     expect(administratorEntity).toBeDefined();
-    
+
     const itemEntity = parsedOutput.find((entity) => entity.name === 'Item');
     expect(itemEntity).toBeDefined();
   });

--- a/src/adapter/entry-points/cli/index.ts
+++ b/src/adapter/entry-points/cli/index.ts
@@ -12,17 +12,18 @@ const isValidConfigFile = (obj: unknown): obj is ConfigFile => {
   if (typeof obj !== 'object' || obj === null) {
     return false;
   }
-  const config = obj as Record<string, unknown>;
-  
-  if (config.excludeTypeNames !== undefined) {
-    if (!Array.isArray(config.excludeTypeNames)) {
+  if (!('excludeTypeNames' in obj)) {
+    return false;
+  }
+  if (obj.excludeTypeNames !== undefined) {
+    if (!Array.isArray(obj.excludeTypeNames)) {
       return false;
     }
-    if (!config.excludeTypeNames.every((item) => typeof item === 'string')) {
+    if (!obj.excludeTypeNames.every((item) => typeof item === 'string')) {
       return false;
     }
   }
-  
+
   return true;
 };
 

--- a/src/adapter/entry-points/cli/index.ts
+++ b/src/adapter/entry-points/cli/index.ts
@@ -2,19 +2,68 @@
 import { Command } from 'commander';
 import { GetDefinitionByPathUseCase } from '../../../domain/usecases/GetDefinitionByPathUseCase';
 import { TsMorphEntityDefinitionRepository } from '../../repositories/TsMorphEntityDefinitionRepository';
+import { readFileSync } from 'fs';
+
+type ConfigFile = {
+  excludeTypeNames?: string[];
+};
+
+const isValidConfigFile = (obj: unknown): obj is ConfigFile => {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
+  const config = obj as Record<string, unknown>;
+  
+  if (config.excludeTypeNames !== undefined) {
+    if (!Array.isArray(config.excludeTypeNames)) {
+      return false;
+    }
+    if (!config.excludeTypeNames.every((item) => typeof item === 'string')) {
+      return false;
+    }
+  }
+  
+  return true;
+};
 
 const program = new Command();
 program
   .argument('<path>', 'Path of domain entity directory')
+  .option('-c, --config <configPath>', 'Path to configuration file (JSON)')
   .name('Get entity definitions')
   .description(
     'Get entity definitions and relation definitions from types of TypeScript in src directory',
   )
-  .action(async (path: string) => {
+  .action(async (path: string, options: { config?: string }) => {
+    let configFile: ConfigFile | undefined;
+
+    if (options.config) {
+      try {
+        const configContent = readFileSync(options.config, 'utf-8');
+        const parsedConfig = JSON.parse(configContent) as unknown;
+
+        if (!isValidConfigFile(parsedConfig)) {
+          console.error(
+            'Error: Invalid configuration file format. Expected format: { excludeTypeNames?: string[] }',
+          );
+          process.exit(1);
+        }
+
+        configFile = parsedConfig;
+      } catch (error) {
+        if (error instanceof Error) {
+          console.error(`Error reading configuration file: ${error.message}`);
+        } else {
+          console.error('Error reading configuration file');
+        }
+        process.exit(1);
+      }
+    }
+
     const useCase = new GetDefinitionByPathUseCase(
       new TsMorphEntityDefinitionRepository(),
     );
-    const res = await useCase.run(path);
+    const res = await useCase.run(path, configFile);
     console.log(JSON.stringify(res));
   });
 if (process.argv) {

--- a/src/adapter/entry-points/function/getEntityDefinitions.ts
+++ b/src/adapter/entry-points/function/getEntityDefinitions.ts
@@ -1,6 +1,15 @@
-import { GetDefinitionByPathUseCase } from '../../../domain/usecases/GetDefinitionByPathUseCase';
+import {
+  GetDefinitionByPathUseCase,
+  GetDefinitionByPathOptions,
+} from '../../../domain/usecases/GetDefinitionByPathUseCase';
 import { TsMorphEntityDefinitionRepository } from '../../repositories/TsMorphEntityDefinitionRepository';
 
-export const getEntityDefinitions = new GetDefinitionByPathUseCase(
-  new TsMorphEntityDefinitionRepository(),
-).run;
+export const getEntityDefinitions = (
+  directoryPath: string,
+  options?: GetDefinitionByPathOptions,
+) => {
+  const useCase = new GetDefinitionByPathUseCase(
+    new TsMorphEntityDefinitionRepository(),
+  );
+  return useCase.run(directoryPath, options);
+};

--- a/src/domain/usecases/GetDefinitionByPathUseCase.test.ts
+++ b/src/domain/usecases/GetDefinitionByPathUseCase.test.ts
@@ -279,6 +279,133 @@ describe('GetDefinitionByPathUseCase', () => {
         directoryPath,
       );
     });
+
+    it('excludes specified type names when excludeTypeNames option is provided', async () => {
+      const directoryPath = '/example/directory/path';
+      const allEntityDefinitions: EntityDefinition[] = [
+        {
+          name: 'User',
+          properties: [
+            {
+              name: 'id',
+              propertyType: 'string',
+              isReference: false,
+              isUnique: false,
+              isNullable: false,
+              isArray: false,
+              acceptableValues: null,
+            },
+          ],
+        },
+        {
+          name: 'Group',
+          properties: [
+            {
+              name: 'id',
+              propertyType: 'string',
+              isReference: false,
+              isUnique: false,
+              isNullable: false,
+              isArray: false,
+              acceptableValues: null,
+            },
+          ],
+        },
+        {
+          name: 'UserGroup',
+          properties: [
+            {
+              name: 'id',
+              propertyType: 'string',
+              isReference: false,
+              isUnique: false,
+              isNullable: false,
+              isArray: false,
+              acceptableValues: null,
+            },
+          ],
+        },
+      ];
+
+      const expectedEntityDefinitions: EntityDefinition[] = [
+        {
+          name: 'User',
+          properties: [
+            {
+              name: 'id',
+              propertyType: 'string',
+              isReference: false,
+              isUnique: false,
+              isNullable: false,
+              isArray: false,
+              acceptableValues: null,
+            },
+          ],
+        },
+      ];
+
+      const { useCase, entityDefinitionRepository } =
+        createUseCaseAndMockRepositories();
+      entityDefinitionRepository.find.mockResolvedValueOnce(
+        allEntityDefinitions,
+      );
+      const result = await useCase.run(directoryPath, {
+        excludeTypeNames: ['Group', 'UserGroup'],
+      });
+
+      expect(result).toEqual(expectedEntityDefinitions);
+      expect(entityDefinitionRepository.find).toHaveBeenCalledWith(
+        directoryPath,
+      );
+    });
+
+    it('returns all definitions when excludeTypeNames is empty array', async () => {
+      const directoryPath = '/example/directory/path';
+      const allEntityDefinitions: EntityDefinition[] = [
+        {
+          name: 'User',
+          properties: [
+            {
+              name: 'id',
+              propertyType: 'string',
+              isReference: false,
+              isUnique: false,
+              isNullable: false,
+              isArray: false,
+              acceptableValues: null,
+            },
+          ],
+        },
+        {
+          name: 'Group',
+          properties: [
+            {
+              name: 'id',
+              propertyType: 'string',
+              isReference: false,
+              isUnique: false,
+              isNullable: false,
+              isArray: false,
+              acceptableValues: null,
+            },
+          ],
+        },
+      ];
+
+      const { useCase, entityDefinitionRepository } =
+        createUseCaseAndMockRepositories();
+      entityDefinitionRepository.find.mockResolvedValueOnce(
+        allEntityDefinitions,
+      );
+      const result = await useCase.run(directoryPath, {
+        excludeTypeNames: [],
+      });
+
+      expect(result).toEqual(allEntityDefinitions);
+      expect(entityDefinitionRepository.find).toHaveBeenCalledWith(
+        directoryPath,
+      );
+    });
   });
   const createUseCaseAndMockRepositories = () => {
     const entityDefinitionRepository = createMockEntityDefinitionRepository();

--- a/src/domain/usecases/GetDefinitionByPathUseCase.ts
+++ b/src/domain/usecases/GetDefinitionByPathUseCase.ts
@@ -17,12 +17,10 @@ export class GetDefinitionByPathUseCase {
       directoryPath,
     );
 
-    if (options?.excludeTypeNames && options.excludeTypeNames.length > 0) {
-      return entityDefinitions.filter(
-        (def) => !options.excludeTypeNames!.includes(def.name),
-      );
-    }
-
-    return entityDefinitions;
+    return entityDefinitions.filter(
+      (def) =>
+        !options?.excludeTypeNames ||
+        !options.excludeTypeNames.includes(def.name),
+    );
   };
 }

--- a/src/domain/usecases/GetDefinitionByPathUseCase.ts
+++ b/src/domain/usecases/GetDefinitionByPathUseCase.ts
@@ -1,14 +1,28 @@
 import { EntityDefinitionRepository } from './adapter-interfaces/EntityDefinitionRepository';
 import { EntityDefinition } from '../entities/EntityDefinition';
 
+export type GetDefinitionByPathOptions = {
+  excludeTypeNames?: string[];
+};
+
 export class GetDefinitionByPathUseCase {
   constructor(
     readonly entityDefinitionRepository: EntityDefinitionRepository,
   ) {}
-  run = async (directoryPath: string): Promise<EntityDefinition[]> => {
+  run = async (
+    directoryPath: string,
+    options?: GetDefinitionByPathOptions,
+  ): Promise<EntityDefinition[]> => {
     const entityDefinitions = await this.entityDefinitionRepository.find(
       directoryPath,
     );
+
+    if (options?.excludeTypeNames && options.excludeTypeNames.length > 0) {
+      return entityDefinitions.filter(
+        (def) => !options.excludeTypeNames!.includes(def.name),
+      );
+    }
+
     return entityDefinitions;
   };
 }

--- a/testdata/ast-to-entity-definitions.json
+++ b/testdata/ast-to-entity-definitions.json
@@ -1,0 +1,3 @@
+{
+  "excludeTypeNames": ["Administrator", "Item"]
+}


### PR DESCRIPTION
Add optional configuration to exclude specific type names from entity definitions output.

## Changes
- Add GetDefinitionByPathOptions type with excludeTypeNames property
- Update GetDefinitionByPathUseCase.run() to accept options parameter
- Add --config CLI option to load configuration from JSON file
- Update getEntityDefinitions function to accept options parameter
- Add validation for configuration file format
- Add tests for exclude functionality and backward compatibility
- Create sample configuration file in testdata

Closes #289